### PR TITLE
Fixed authorization/bearer token grabbing

### DIFF
--- a/main.py
+++ b/main.py
@@ -80,7 +80,7 @@ class ProlificUpdater:
         start = time()
         while not status:
             anchor_url = "https://www.recaptcha.net/recaptcha/api2/anchor?ar=1&k=6LeMGXkUAAAAAOlMpEUm2UOldiq38QgBPJz5-Q-7&co=aHR0cHM6Ly9pbnRlcm5hbC1hcGkucHJvbGlmaWMuY286NDQz&hl=fr&v=gWN_U6xTIPevg0vuq7g1hct0&size=invisible&cb=igv4yino6y0f"
-            reCaptcha_response = reCaptchaV3(anchor_url)
+            # reCaptcha_response = reCaptchaV3(anchor_url)
             end = time()
             print(f"Captcha solved in {end-start}s")
             driver.execute_script(f'document.getElementsByName("username")[0].value = "{config["mail"]}"')
@@ -88,7 +88,7 @@ class ProlificUpdater:
             # driver.execute_script(f'document.getElementById("g-recaptcha-response-100000").innerHTML="{reCaptcha_response}";')
             driver.find_element(By.XPATH, '//button[@type="submit"]').click()
             sleep(3)
-            if driver.current_url =="https://internal-api.prolific.com/auth/accounts/login/":
+            if driver.current_url =="https://auth.prolific.com/u/login":
                 status = 0
                 print("Failed to log in, retrying...")
                 driver.get(pageurl)

--- a/main.py
+++ b/main.py
@@ -34,6 +34,7 @@ class ProlificUpdater:
         headers = CaseInsensitiveDict()
         headers["Accept"] = "application/json, text/plain, */*"
         headers["Authorization"] = self.bearer
+        headers["x-legacy-auth"] = "false"
         return get(url, headers=headers)
 
     def reservePlace(self, id) -> Response:
@@ -41,6 +42,7 @@ class ProlificUpdater:
         headers = CaseInsensitiveDict()
         headers["Accept"] = "application/json"
         headers["Authorization"] = self.bearer
+        headers["x-legacy-auth"] = "false"
         postObj = {"study_id": id, "participant_id": self.participantId}
         return post(url, headers=headers, data = postObj)
 

--- a/main.py
+++ b/main.py
@@ -64,7 +64,7 @@ class ProlificUpdater:
     
     def get_bearer_token(self) -> str:
         print("Getting a new bearer token...")
-        pageurl = 'https://internal-api.prolific.com/auth/accounts/login/'
+        pageurl = 'https://auth.prolific.com/u/login'
 
         options = Options()
         options.add_experimental_option("excludeSwitches", ["enable-automation"])
@@ -85,8 +85,8 @@ class ProlificUpdater:
             print(f"Captcha solved in {end-start}s")
             driver.execute_script(f'document.getElementsByName("username")[0].value = "{config["mail"]}"')
             driver.execute_script(f'document.getElementsByName("password")[0].value = "{config["password"]}"')
-            driver.execute_script(f'document.getElementById("g-recaptcha-response-100000").innerHTML="{reCaptcha_response}";')
-            driver.find_element(By.ID, "login").submit()
+            # driver.execute_script(f'document.getElementById("g-recaptcha-response-100000").innerHTML="{reCaptcha_response}";')
+            driver.find_element(By.XPATH, '//button[@type="submit"]').click()
             sleep(3)
             if driver.current_url =="https://internal-api.prolific.com/auth/accounts/login/":
                 status = 0
@@ -99,11 +99,14 @@ class ProlificUpdater:
             driver.refresh()
             while True:
                 for request in driver.requests:
-                    if request.response:
-                        if request.url.startswith("https://internal-api.prolific.com/openid/authorize?client_id="):
-                            new_bearer = request.response.headers['location'].split("&")[0].split("access_token=")[-1]
-                            print(f"Got a new bearer token ! : {new_bearer}\n")
-                            return new_bearer
+                    if "https://internal-api.prolific.com/api/v1/" in request.url:
+                            try:
+                                new_bearer = request.headers["Authorization"]
+                                print(new_bearer)
+                                print(f"Got a new bearer token ! : {new_bearer}\n")
+                                return new_bearer
+                            except:
+                                pass
                     sleep(0.5)
 
 


### PR DESCRIPTION
Hi there,

These are my changes to fix the token grabbing when logging in. **I am not 100% sure if these fixes work** so hopefully someone else can pull and test. I have my own personal prolific python script based on UnMars' authorization function, and on finding a fix for that I attempted to recreate the fix for this script, however I am not sure if it works. 

For reference, the changes I made to fix functionality for my own script:
1. Added the x-legacy-auth header and set it to false. For some reason, prolific doesn't allow API requests without this header, at least through my tests.
2. Changed the `pageurl` default login url to `https://auth.prolific.com/u/login`, prolific does not like when you log in through internal-api.prolific.com
3. Commented out the captcha feature, I am not 100% sure if a captcha is still used however I could not find any element with ID `g-recaptcha-response-100000` or similar when logging into the new url, so I commented it out and it seemed to work.
4. Finding the submit button is now done through finding a button of type "submit" using `By.XPATH`, auth.prolific.com doesn't have a button with id `login`
5. In order to get the Bearer, the code cycles through each request to the API made after signing in and checks if an Authorization header was included, if so it grabs it. This token is a lot bigger than before but it seems to work in my script for API requests.

Hopefully the adapted code works as it does in my script, and if not hopefully the information above can be helpful!