### PR TITLE
fixes and changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ python main.py
 ```
 
 ## Configuration
-Edit the settings.json file.
+Edit the config.json file.
 
 |Config|Usage|
 | :------------: | :------------: |
 |auto_renew_bearer|"True" or "False" *(default True)*|
+|stop_on_idle|"True" or "False" *(default True)*|
 |mail|Your mail on Prolific *(used to renew token)*|
 |password|Your password on Prolific *(used to renew token)*|
 |Prolific_ID|Your Prolific ID|

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Edit the config.json file.
 |Config|Usage|
 | :------------: | :------------: |
 |auto_renew_bearer|"True" or "False" *(default True)*|
-|stop_on_idle|"True" or "False" *(default True)*|
+|pause_on_idle|"True" or "False" *(default True)*|
 |mail|Your mail on Prolific *(used to renew token)*|
 |password|Your password on Prolific *(used to renew token)*|
 |Prolific_ID|Your Prolific ID|

--- a/config/config.json
+++ b/config/config.json
@@ -1,10 +1,10 @@
 {
-    "auto_renew_bearer": "True",
-    "pause_on_idle": "True",
+    "auto_renew_bearer" : "True",
+    "pause_on_idle" : "True",
 
-    "mail": "",
-    "password": "",
-    "Prolific_ID": "",
+    "mail" : "",
+    "password" : "",
+    "Prolific_ID" : "",
 
-    "wait_time": 30
+    "wait_time" : 30
 }

--- a/config/config.json
+++ b/config/config.json
@@ -1,10 +1,10 @@
 {
-  "auto_renew_bearer": "True",
-  "pause_on_idle": "True",
+    "auto_renew_bearer": "True",
+    "pause_on_idle": "True",
 
-  "mail": "",
-  "password": "",
-  "Prolific_ID": "",
+    "mail": "",
+    "password": "",
+    "Prolific_ID": "",
 
-  "wait_time": 30
+    "wait_time": 30
 }

--- a/config/config.json
+++ b/config/config.json
@@ -1,9 +1,10 @@
 {
-    "auto_renew_bearer" : "True", 
+  "auto_renew_bearer": "True",
+  "pause_on_idle": "True",
 
-    "mail" : "",
-    "password" : "",
-    "Prolific_ID": "",
+  "mail": "",
+  "password": "",
+  "Prolific_ID": "",
 
-    "wait_time" : 30
+  "wait_time": 30
 }

--- a/main.py
+++ b/main.py
@@ -136,16 +136,17 @@ class ProlificUpdater:
         print("results : ", results)
         if results:
             if results != self.oldResults:
+                currency_symbol = "£" if str(results[0]["study_reward"]["currency"]) == "GBP" else "$"
                 console.print(
-                    f"""Trying to join {results[0]["name"]} ([bold green]${str(float(results[0]["study_reward"]["amount"])/100)}[/bold green])"""
+                    f"""Trying to join {results[0]["name"]} ([bold green]{currency_symbol}{str(float(results[0]["study_reward"]["amount"])/100)}[/bold green])"""
                 )
                 reserve_place_res = self.reservePlace(id=results[0]["id"])
                 if reserve_place_res.status_code == 400:
                     console.print(f"""[bold red][+] Error code {str(reserve_place_res.json()["error"]["error_code"])}
                                       \nTitle : {str(reserve_place_res.json()["error"]["title"])}
                                       \nDetails : {str(reserve_place_res.json()["error"]["detail"])}""")
-                    status.stop()
-                    exit()
+                    self.oldResults = results
+                    return False
                 else:
                     playsound(rf"{Path(__file__).parent}\alert.wav", True)
                     a_website = "https://app.prolific.com/studies"
@@ -223,8 +224,9 @@ if __name__ == "__main__":
             console.print(text)
             sleep(5)
             input("Press enter to resume study search")
+            status.start()
 
-        if platform.system() == "Windows":
+        if strtobool(config["pause_on_idle"]) and platform.system() == "Windows":
             idle_duration = get_idle_duration()
             if idle_duration >= 600:  # 10 minutes in seconds
                 pause_script()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-playsound>=1.3.0
+playsound@git+https://github.com/taconi/playsound
 PyPasser>=0.0.5
 requests>=2.31.0
 rich>=13.5.2
 selenium>=4.16.0
 selenium_wire>=5.1.0
 webdriver_manager>=4.0.1
+blinker==1.7.0


### PR DESCRIPTION
- added configuration option "pause_on_idle" (default: True) that can be set to false in the case that the user wants the script to be running while they're not active on their computer (e.g while studying).
- fixed script incorrectly showing reward as $ for studies that paid out in £.
- fixed "Waiting for study..." console status not reappearing upon resuming study search.
- fixed pip error while trying to install playsound on most systems ([Issue #150 on playsound repository](https://github.com/TaylorSMarks/playsound/issues/150)).
- fixed module error while trying to run the script due to having a version of blinker higher than 1.7.0 (selenium-wire only works with 1.7.0 and lower).
- modified script to keep searching for studies after attempting to join a study that returned an error code.